### PR TITLE
Lcd rotation multi data display 002

### DIFF
--- a/Arduino_protocol_draft.md
+++ b/Arduino_protocol_draft.md
@@ -77,8 +77,9 @@ example update the text showed on an LCD display.
 
 #### WRITE MESSAGE (>5 bytes):
 ```
-0001 0000 - PACKET_ID - 0001 0010 - 0000 0000 - 0000 0101 - hello world\ngood
+0001 0000 - PACKET_ID - 0001 0010 - 0000 0000 - 0000 0101 - hello world\ngood\nSLOT
 ```
+SLOT is a one byte number that defines the LCD slot the text will go to.
 
 #### RESPONSE PACKET (5 bytes):
 ```

--- a/Arduino_protocol_draft.md
+++ b/Arduino_protocol_draft.md
@@ -16,9 +16,9 @@ The packets have the following format:
 B0: High nible for protocol version (ie. 0001 for v1).
     Lower nible for packet type (ie. Request 0000, Response 1111)
 B1: Packet ID, this field is to match packet request and responses. So technically we can have up to 255 packets in transit (not gonna happen ever xD)
-B2: High nible for Operation type (ie. Read 0000, Write 0001, Ping 1111, Control 1110)
+B2: High nible for Operation type (ie. Read 0000, Write 0001, Ping 1111, Control 1110, Error 1100)
     Lower nible specifics of the operation (ie. read XXX sensor). Use 1111 to list sensors.
-B3: Data format (ie. int, float represented in binary, way too many options I guess...)
+B3: Data format (ie. int, float represented in binary, way too many options I guess...). If B2 high nible is Error, this is the error code.
 B4: Total number of bytes in the packet. The smallest packet is 5 bytes (PING packet, request/response). If I moved this to B3, the smallest packet could be 4 bytes instead... (maybe one day).
 B5 to B255: Potentially data
 ```
@@ -84,4 +84,10 @@ SLOT is a one byte number that defines the LCD slot the text will go to.
 #### RESPONSE PACKET (5 bytes):
 ```
 0001 1111 - PACKET_ID - 0001 0010 - 0000 0000 - 0000 0101
+```
+#### ERROR RESPONSE (5 bytes):
+Error message, high nible of B2 is 1100 (low nible can be anything) and B3 contains de actual error code to match
+later on with the function within the Arduino.
+```
+0001 1111 - PACKET_ID - 1100 0010 - ERROR_CODE - 0000 0101
 ```

--- a/arduino.ino
+++ b/arduino.ino
@@ -286,7 +286,7 @@ boolean read_screen_data(byte size)
     return false;
   }
 
-  available_lcd_pairs[16*slot + 16 + 15]; = '\0';
+  available_lcd_pairs[16*slot + 16 + 15] = '\0';
 
   //Updating the bitmap, first getting the position and then updating the bitmap
   position = position << slot;
@@ -395,6 +395,8 @@ void loop(void)
 {
   if(rotate_lcd == 0)
   {
+    lcd.clear();
+    delay(100);
     rotate_lcd_now();
     rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;
   }

--- a/arduino.ino
+++ b/arduino.ino
@@ -316,11 +316,10 @@ boolean read_screen_data(byte size)
     }
     rboundary--;
   }
-
+  ctr++;
   boundary = boundary - ctr;
+  read = &receive_buffer[5 + ctr];
 
-  read = read + ctr + 1;
-  boundary = boundary - 1;
   ctr = 0;
   rboundary = 16;
 
@@ -339,8 +338,9 @@ boolean read_screen_data(byte size)
     }
     rboundary--;
   }
-
+  ctr++;
   boundary = boundary - ctr;
+
   if(boundary != 0)
   {// This means we have either read beyond the packet or there's left to read.
     return_error_code = NOT_ALL_READ;

--- a/arduino.ino
+++ b/arduino.ino
@@ -285,7 +285,8 @@ boolean send_sensor_read(byte packet_protocol_version, byte packet_id, byte sens
 boolean read_screen_data(byte size)
 {
   // Data should start in B5 in receive_buffer. Two strings should come, separated by '\n'
-  byte *read, *aux_addr;
+  byte *read;
+  char *aux_addr;
   byte ctr = 0;
   byte boundary = size - 5;// Used to make sure we don't read beyond the what we received.
   byte rboundary = 16;// To make sure I don't go beyond the size of the LCD row
@@ -300,6 +301,7 @@ boolean read_screen_data(byte size)
     return_error_code = SLOT_EXCEEDED;
     return false;//This should result in an error back to the Rasp.
   }
+  boundary--;// Because slot is the last byte and was not counting it :)
 
   aux_addr = &available_lcd_pairs[16*slot];
 

--- a/arduino.ino
+++ b/arduino.ino
@@ -303,7 +303,7 @@ boolean read_screen_data(byte size)
   }
   boundary--;// Because slot is the last byte and was not counting it :)
 
-  aux_addr = &available_lcd_pairs[16*slot];
+  aux_addr = &available_lcd_pairs[32*slot];
 
   while(rboundary > 0)
   {
@@ -325,7 +325,7 @@ boolean read_screen_data(byte size)
   ctr = 0;
   rboundary = 16;
 
-  aux_addr = &available_lcd_pairs[16*slot + 16];
+  aux_addr = &available_lcd_pairs[32*slot + 16];
 
   while(rboundary > 0)
   {

--- a/arduino.ino
+++ b/arduino.ino
@@ -19,6 +19,7 @@ byte used_pairs = B00000001;//Bitmap of pairs in use, remember pair[0] is used b
 int rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;//Considering the delay in loop() is 50ms, this results in ~2000ms between LCD rotation
 byte return_error_code = 0;
 byte bad_writes = 0;// This should be used to track situations where serial.write() didn't send all the bytes it was supossed to.
+boolean initialized = false;
 
 // Setup a oneWire instance to communicate with any OneWire devices
 // (not just Maxim/Dallas temperature ICs)
@@ -361,7 +362,7 @@ boolean read_screen_data(byte size)
   //Updating the bitmap, first getting the position and then updating the bitmap
   position = position << slot;
   used_pairs = used_pairs | position;
-
+  initialized = true;
   return true;
 }
 
@@ -495,7 +496,7 @@ void rotate_lcd_now_simplified()
 
 void loop(void)
 {
-  if(rotate_lcd == 0)
+  if(rotate_lcd == 0 && initialized)
   {
     //rotate_lcd_now();
     rotate_lcd_now_simplified();

--- a/arduino.ino
+++ b/arduino.ino
@@ -485,7 +485,7 @@ void rotate_lcd_now_simplified()
   current_pair++;
   if(current_pair>=LCD_PAIRS)
   {
-    current_pair=0;
+    current_pair=1;//Instead of starting from 0 and showing the default text, I directly loop now between [1,LCD_PAIRS)
   }
 
   update_screen();

--- a/arduino.ino
+++ b/arduino.ino
@@ -16,7 +16,7 @@ available_lcd_pairs[0] = "-Just Started-";
 available_lcd_pairs[16] = "No Data Avail.";
 byte current_pair = 0;//The one present on the LCD at the moment.
 byte used_pairs = B00000001;//Bitmap of pairs in use, remember pair[0] is used by default
-byte rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;//Considering the delay in loop() is 50ms, this results in ~2000ms between LCD rotation
+int rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;//Considering the delay in loop() is 50ms, this results in ~2000ms between LCD rotation
 
 // Setup a oneWire instance to communicate with any OneWire devices
 // (not just Maxim/Dallas temperature ICs)
@@ -81,7 +81,7 @@ void setup(void)
 
   // Start lcd
   lcd.begin(16, 2);
-  update_screen()
+  update_screen();
 }
 
 // Pull all the available data from the UART buffer
@@ -247,17 +247,17 @@ boolean read_screen_data(byte size)
   {
     if (*(read + ctr) != '\n')
     {//Copy the content from the receive_buffer
-      row0[ctr] = *(read + ctr);
+      available_lcd_pairs[16*slot + ctr] = *(read + ctr);
       ctr++;
     }
     else
     {//Fill up the rest with spaces to override any previously stored characters
-      row0[ctr + rboundary - 1] = 0x20;
+      available_lcd_pairs[16*slot + ctr + rboundary - 1] = 0x20;
     }
     rboundary--;
   }
 
-  row0[15]='\0';//No matter what happens I close the string at the edge of the array
+  available_lcd_pairs[16*slot + 15]='\0';//No matter what happens I close the string at the edge of the array
 
   boundary = boundary - ctr;
 
@@ -270,12 +270,12 @@ boolean read_screen_data(byte size)
   {
     if(*(read + ctr) != '\n')
     {//Copy the content from the receive_buffer
-      row1[ctr] = *(read + ctr);
+      available_lcd_pairs[16*slot + 16 + ctr] = *(read + ctr);
       ctr++;
     }
     else
     {//Fill up the rest with spaces to override any previously stored characters
-      row1[ctr + rboundary - 1] = 0x20;
+      available_lcd_pairs[16*slot + 16 + ctr + rboundary - 1] = 0x20;
     }
     rboundary--;
   }
@@ -286,18 +286,7 @@ boolean read_screen_data(byte size)
     return false;
   }
 
-  row1[15] = '\0';
-
-  aux_row0 = &available_lcd_pairs[16*slot];
-  aux_row1 = &available_lcd_pairs[16*slot + 16];
-
-  ctr = 0;
-  while(ctr < 16)
-  {
-    aux_row0[ctr] = row0[ctr];
-    aux_row1[ctr] = row1[ctr];
-    boundary++;
-  }
+  available_lcd_pairs[16*slot + 16 + 15]; = '\0';
 
   //Updating the bitmap, first getting the position and then updating the bitmap
   position = position << slot;

--- a/arduino.ino
+++ b/arduino.ino
@@ -12,8 +12,38 @@
 #define LCD_ROTATION_FACTOR 40
 #define LCD_PAIRS_SIZE 32*LCD_PAIRS
 char available_lcd_pairs[LCD_PAIRS_SIZE];
-available_lcd_pairs[0] = "-Just Started-";
-available_lcd_pairs[16] = "No Data Avail.";
+available_lcd_pairs[0] = ' ';"
+available_lcd_pairs[1] = '-';
+available_lcd_pairs[2] = 'J';
+available_lcd_pairs[3] = 'u';
+available_lcd_pairs[4] = 's';
+available_lcd_pairs[5] = 't';
+available_lcd_pairs[6] = ' ';
+available_lcd_pairs[7] = 'S';
+available_lcd_pairs[8] = 't';
+available_lcd_pairs[9] = 'a';
+available_lcd_pairs[10] = 'r';
+available_lcd_pairs[11] = 't';
+available_lcd_pairs[12] = 'e';
+available_lcd_pairs[13] = 'd';
+available_lcd_pairs[14] = '-';
+available_lcd_pairs[15] = '\0';
+available_lcd_pairs[16] = ' ';"
+available_lcd_pairs[17] = 'N';
+available_lcd_pairs[18] = 'o';
+available_lcd_pairs[19] = ' ';
+available_lcd_pairs[20] = 'D';
+available_lcd_pairs[21] = 'a';
+available_lcd_pairs[22] = 't';
+available_lcd_pairs[23] = 'a;
+available_lcd_pairs[24] = ' ';
+available_lcd_pairs[25] = 'a';
+available_lcd_pairs[26] = 'v';
+available_lcd_pairs[27] = 't';
+available_lcd_pairs[28] = 'a';
+available_lcd_pairs[29] = 'i';
+available_lcd_pairs[30] = '.';
+available_lcd_pairs[31] = '\0';
 byte current_pair = 0;//The one present on the LCD at the moment.
 byte used_pairs = B00000001;//Bitmap of pairs in use, remember pair[0] is used by default
 int rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;//Considering the delay in loop() is 50ms, this results in ~2000ms between LCD rotation
@@ -396,6 +426,10 @@ void loop(void)
   if(rotate_lcd == 0)
   {
     lcd.clear();
+    lcd.setCursor(0,0);
+    lcd.print("WTF");
+    lcd.setCursor(0,1);
+    lcd.print("is this...");
     delay(100);
     rotate_lcd_now();
     rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;

--- a/arduino.ino
+++ b/arduino.ino
@@ -75,6 +75,7 @@ boolean packet_ready;
 
 void setup(void)
 {
+  int aux;
   available_lcd_pairs[0] = ' ';
   available_lcd_pairs[1] = '-';
   available_lcd_pairs[2] = 'J';
@@ -107,6 +108,12 @@ void setup(void)
   available_lcd_pairs[29] = 'i';
   available_lcd_pairs[30] = '.';
   available_lcd_pairs[31] = ' ';
+  aux = 32;
+  while(aux < LCD_PAIRS_SIZE)
+  {
+    available_lcd_pairs[aux] = 'X';
+    aux++;
+  }
 
   // start serial port
   Serial.begin(9600);

--- a/arduino.ino
+++ b/arduino.ino
@@ -91,7 +91,7 @@ void setup(void)
   available_lcd_pairs[20] = 'D';
   available_lcd_pairs[21] = 'a';
   available_lcd_pairs[22] = 't';
-  available_lcd_pairs[23] = 'a;
+  available_lcd_pairs[23] = 'a';
   available_lcd_pairs[24] = ' ';
   available_lcd_pairs[25] = 'a';
   available_lcd_pairs[26] = 'v';
@@ -426,12 +426,6 @@ void loop(void)
 {
   if(rotate_lcd == 0)
   {
-    lcd.clear();
-    lcd.setCursor(0,0);
-    lcd.print("WTF");
-    lcd.setCursor(0,1);
-    lcd.print("is this...");
-    delay(100);
     rotate_lcd_now();
     rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;
   }

--- a/arduino.ino
+++ b/arduino.ino
@@ -373,7 +373,6 @@ boolean update_screen()
 
   lcd.clear();
 
-  lcd.setCursor(0,0);
   while(ctr<16)
   {
     lcd.setCursor(ctr,0);
@@ -382,7 +381,6 @@ boolean update_screen()
   }
 
   ctr=0;
-  lcd.setCursor(0,1);
   while(ctr<16)
   {
     lcd.setCursor(ctr,1);
@@ -478,11 +476,27 @@ void rotate_lcd_now()
   return;
 }
 
+// Dumbly rotates through all the pairs 1 by 1 until it goes back to 0.
+void rotate_lcd_now_simplified()
+{
+  // So now, try the moving current_pair forward and check if that pair is enabled in the bitmap.
+  current_pair++;
+  if(current_pair>7)
+  {
+    current_pair=0;
+  }
+
+  update_screen();
+
+  return;
+}
+
 void loop(void)
 {
   if(rotate_lcd == 0)
   {
-    rotate_lcd_now();
+    //rotate_lcd_now();
+    rotate_lcd_now_simplified();
     rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;
   }
   if(packet_ready)

--- a/arduino.ino
+++ b/arduino.ino
@@ -496,11 +496,13 @@ void rotate_lcd_now_simplified()
 
 void loop(void)
 {
-  if(rotate_lcd == 0 && initialized)
+  if(rotate_lcd == 0)
   {
-    //rotate_lcd_now();
-    rotate_lcd_now_simplified();
     rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;
+    if(initialized)
+    {  //rotate_lcd_now();
+      rotate_lcd_now_simplified();
+    }
   }
   if(packet_ready)
   {

--- a/arduino.ino
+++ b/arduino.ino
@@ -330,13 +330,28 @@ boolean read_screen_data(byte size)
 // First needs to pull out the two strings one for each row :(
 boolean update_screen()
 {
-  // Set cursor position to write
-  lcd.clear();
-  lcd.setCursor(0,0);
-  lcd.print(available_lcd_pairs[0]);
-  lcd.setCursor(0,1);
-  lcd.print(available_lcd_pairs[16]);
+  int ctr=0;
+  char *addr;
+  addr = &available_lcd_pairs[current_pair*32];
 
+  lcd.clear();
+
+  lcd.setCursor(0,0);
+  while(ctr<16)
+  {
+    lcd.setCursor(ctr,0);
+    lcd.write(addr[ctr]);
+    ctr++;
+  }
+
+  ctr=0;
+  lcd.setCursor(0,1);
+  while(ctr<16)
+  {
+    lcd.setCursor(ctr,1);
+    lcd.write(addr[ctr+16]);
+    ctr++;
+  }
   return true;
 }
 
@@ -413,11 +428,7 @@ void rotate_lcd_now()
     current_pair=0;//Resesting it for now, but this should go to at least 1 to prevent showing the default data in pair[0]
   }
 
-  lcd.clear();
-  lcd.setCursor(0,0);
-  lcd.print(available_lcd_pairs[16*(current_pair+1)]);
-  lcd.setCursor(0,1);
-  lcd.print(available_lcd_pairs[16*(current_pair+1)+16]);
+  update_screen();
 
   return;
 }

--- a/arduino.ino
+++ b/arduino.ino
@@ -8,7 +8,9 @@
 
 #define LOOP_DELAY 50
 // Number of rotating pairs for the LCD. Pairs are 32 bytes size.
-#define LCD_PAIRS 8
+#define LCD_PAIRS 4
+#define LCD_ROWS 2
+#define LCD_COLUMNS 16
 #define LCD_ROTATION_FACTOR 40
 #define LCD_PAIRS_SIZE 32*LCD_PAIRS
 char available_lcd_pairs[LCD_PAIRS_SIZE];
@@ -103,9 +105,9 @@ void setup(void)
   available_lcd_pairs[24] = ' ';
   available_lcd_pairs[25] = 'a';
   available_lcd_pairs[26] = 'v';
-  available_lcd_pairs[27] = 't';
-  available_lcd_pairs[28] = 'a';
-  available_lcd_pairs[29] = 'i';
+  available_lcd_pairs[27] = 'a';
+  available_lcd_pairs[28] = 'i';
+  available_lcd_pairs[29] = 'l';
   available_lcd_pairs[30] = '.';
   available_lcd_pairs[31] = ' ';
   aux = 32;
@@ -125,7 +127,7 @@ void setup(void)
   buffer_index = 0;
 
   // Start lcd
-  lcd.begin(16, 2);
+  lcd.begin(LCD_COLUMNS, LCD_ROWS);
   update_screen();
 }
 
@@ -296,7 +298,7 @@ boolean read_screen_data(byte size)
   char *aux_addr;
   byte ctr = 0;
   byte boundary = size - 5;// Used to make sure we don't read beyond the what we received.
-  byte rboundary = 16;// To make sure I don't go beyond the size of the LCD row
+  byte rboundary = LCD_COLUMNS;// To make sure I don't go beyond the size of the LCD row
   byte slot;
   byte position = B00000001;
 
@@ -310,7 +312,7 @@ boolean read_screen_data(byte size)
   }
   boundary--;// Because slot is the last byte and was not counting it :)
 
-  aux_addr = &available_lcd_pairs[32*slot];
+  aux_addr = &available_lcd_pairs[(LCD_ROWS*LCD_COLUMNS)*slot];
 
   while(rboundary > 0)
   {
@@ -330,9 +332,9 @@ boolean read_screen_data(byte size)
   read = &receive_buffer[5 + ctr];
 
   ctr = 0;
-  rboundary = 16;
+  rboundary = LCD_COLUMNS;
 
-  aux_addr = &available_lcd_pairs[32*slot + 16];
+  aux_addr = &available_lcd_pairs[(LCD_ROWS*LCD_COLUMNS)*slot + LCD_COLUMNS];
 
   while(rboundary > 0)
   {
@@ -369,11 +371,11 @@ boolean update_screen()
 {
   int ctr=0;
   char *addr;
-  addr = &available_lcd_pairs[current_pair*32];
+  addr = &available_lcd_pairs[current_pair*(LCD_ROWS*LCD_COLUMNS)];
 
   lcd.clear();
 
-  while(ctr<16)
+  while(ctr<LCD_COLUMNS)
   {
     lcd.setCursor(ctr,0);
     lcd.write(addr[ctr]);
@@ -381,10 +383,10 @@ boolean update_screen()
   }
 
   ctr=0;
-  while(ctr<16)
+  while(ctr<LCD_COLUMNS)
   {
     lcd.setCursor(ctr,1);
-    lcd.write(addr[ctr+16]);
+    lcd.write(addr[ctr+LCD_COLUMNS]);
     ctr++;
   }
   return true;
@@ -481,7 +483,7 @@ void rotate_lcd_now_simplified()
 {
   // So now, try the moving current_pair forward and check if that pair is enabled in the bitmap.
   current_pair++;
-  if(current_pair>7)
+  if(current_pair>=LCD_PAIRS)
   {
     current_pair=0;
   }

--- a/arduino.ino
+++ b/arduino.ino
@@ -422,7 +422,7 @@ void loop(void)
     else
     {
       delay(LOOP_DELAY);
-      rotate_lcd--;
+      rotate_lcd = rotate_lcd - LOOP_DELAY;
     }
   }
 }

--- a/arduino.ino
+++ b/arduino.ino
@@ -12,38 +12,6 @@
 #define LCD_ROTATION_FACTOR 40
 #define LCD_PAIRS_SIZE 32*LCD_PAIRS
 char available_lcd_pairs[LCD_PAIRS_SIZE];
-available_lcd_pairs[0] = ' ';"
-available_lcd_pairs[1] = '-';
-available_lcd_pairs[2] = 'J';
-available_lcd_pairs[3] = 'u';
-available_lcd_pairs[4] = 's';
-available_lcd_pairs[5] = 't';
-available_lcd_pairs[6] = ' ';
-available_lcd_pairs[7] = 'S';
-available_lcd_pairs[8] = 't';
-available_lcd_pairs[9] = 'a';
-available_lcd_pairs[10] = 'r';
-available_lcd_pairs[11] = 't';
-available_lcd_pairs[12] = 'e';
-available_lcd_pairs[13] = 'd';
-available_lcd_pairs[14] = '-';
-available_lcd_pairs[15] = '\0';
-available_lcd_pairs[16] = ' ';"
-available_lcd_pairs[17] = 'N';
-available_lcd_pairs[18] = 'o';
-available_lcd_pairs[19] = ' ';
-available_lcd_pairs[20] = 'D';
-available_lcd_pairs[21] = 'a';
-available_lcd_pairs[22] = 't';
-available_lcd_pairs[23] = 'a;
-available_lcd_pairs[24] = ' ';
-available_lcd_pairs[25] = 'a';
-available_lcd_pairs[26] = 'v';
-available_lcd_pairs[27] = 't';
-available_lcd_pairs[28] = 'a';
-available_lcd_pairs[29] = 'i';
-available_lcd_pairs[30] = '.';
-available_lcd_pairs[31] = '\0';
 byte current_pair = 0;//The one present on the LCD at the moment.
 byte used_pairs = B00000001;//Bitmap of pairs in use, remember pair[0] is used by default
 int rotate_lcd = LCD_ROTATION_FACTOR * LOOP_DELAY;//Considering the delay in loop() is 50ms, this results in ~2000ms between LCD rotation
@@ -100,6 +68,39 @@ boolean packet_ready;
 
 void setup(void)
 {
+  available_lcd_pairs[0] = ' ';
+  available_lcd_pairs[1] = '-';
+  available_lcd_pairs[2] = 'J';
+  available_lcd_pairs[3] = 'u';
+  available_lcd_pairs[4] = 's';
+  available_lcd_pairs[5] = 't';
+  available_lcd_pairs[6] = ' ';
+  available_lcd_pairs[7] = 'S';
+  available_lcd_pairs[8] = 't';
+  available_lcd_pairs[9] = 'a';
+  available_lcd_pairs[10] = 'r';
+  available_lcd_pairs[11] = 't';
+  available_lcd_pairs[12] = 'e';
+  available_lcd_pairs[13] = 'd';
+  available_lcd_pairs[14] = '-';
+  available_lcd_pairs[15] = '\0';
+  available_lcd_pairs[16] = ' ';
+  available_lcd_pairs[17] = 'N';
+  available_lcd_pairs[18] = 'o';
+  available_lcd_pairs[19] = ' ';
+  available_lcd_pairs[20] = 'D';
+  available_lcd_pairs[21] = 'a';
+  available_lcd_pairs[22] = 't';
+  available_lcd_pairs[23] = 'a;
+  available_lcd_pairs[24] = ' ';
+  available_lcd_pairs[25] = 'a';
+  available_lcd_pairs[26] = 'v';
+  available_lcd_pairs[27] = 't';
+  available_lcd_pairs[28] = 'a';
+  available_lcd_pairs[29] = 'i';
+  available_lcd_pairs[30] = '.';
+  available_lcd_pairs[31] = '\0';
+
   // start serial port
   Serial.begin(9600);
   //Serial.println("Dallas Temperature IC Control Library Demo");

--- a/collector.py
+++ b/collector.py
@@ -196,6 +196,7 @@ def main():
                 if last_measure != measure:
                     logging.debug("New measure " + str(measure) + " for Living room, so pushing it to LCD.")
                     last_measure = measure
+                    sensor = 2 #Hardcoding screen1 sensor :)
                     dev.write_sensor(sensor, (measure, "Living Room", 2))
 
                 if openweather_enabled:

--- a/collector.py
+++ b/collector.py
@@ -181,7 +181,7 @@ def main():
             dev.disable()
 
     starttime = time.time()
-
+    last_measure = 0.0
     while not TERMINATE:
         timestamp = str(datetime.datetime.now())
         for dev in DEVICES:
@@ -192,6 +192,10 @@ def main():
                 logging.debug("Sensor read: " + str(measure))
                 store_collected_metric(configuration, timestamp, dev.get_name(), dev.get_sensor_name(sensor), measure)
                 update_temperature_table("livingroom", measure, timestamp)
+
+                if last_measure != float(measure):
+                    last_measure = float(measure)
+                    dev.write_sensor(sensor, (measure, "Living Room", 2))
 
                 if openweather_enabled:
                     sensor = 2

--- a/collector.py
+++ b/collector.py
@@ -192,9 +192,10 @@ def main():
                 logging.debug("Sensor read: " + str(measure))
                 store_collected_metric(configuration, timestamp, dev.get_name(), dev.get_sensor_name(sensor), measure)
                 update_temperature_table("livingroom", measure, timestamp)
-
-                if last_measure != float(measure):
-                    last_measure = float(measure)
+                measure = float(measure)
+                if last_measure != measure:
+                    logging.debug("New measure " + str(measure) + " for Living room, so pushing it to LCD.")
+                    last_measure = measure
                     dev.write_sensor(sensor, (measure, "Living Room", 2))
 
                 if openweather_enabled:

--- a/collector.py
+++ b/collector.py
@@ -108,6 +108,7 @@ def main():
     global TERMINATE
 
     debug = False
+    owo = False
 
     signal.signal(signal.SIGTERM, term_handler)
 
@@ -116,11 +117,6 @@ def main():
     frequency = int(configuration['COLLECTOR']['frequency'])
 
     FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-
-    if debug:
-        logging.basicConfig(filename="collector.log", format=FORMAT, level=logging.DEBUG)
-    else:
-        logging.basicConfig(filename="collector.log", format=FORMAT, level=logging.INFO)
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hdf:", ["help", "debug", "openweather"])
@@ -138,17 +134,25 @@ def main():
             frequency = int(a)
         elif o in ("--openweather"):
             import openweather
-            try:
-                ow = openweather.Openweather(
-                    configuration['COLLECTOR']['openweathermap-key'],
-                    configuration['COLLECTOR']['openweathermap-name'],
-                    configuration['COLLECTOR']['openweathermap-city-id'])
-                openweather_enabled = True
-            except Exception as e:
-                logging.warn("OpenWeather has been disabled :(... due to " + str(e))
-                openweather_enabled = False
+            owo = True
         else:
             assert False, "Unhandled option"
+
+    if debug:
+        logging.basicConfig(filename="collector.log", format=FORMAT, level=logging.DEBUG)
+    else:
+        logging.basicConfig(filename="collector.log", format=FORMAT, level=logging.INFO)
+
+    if owo:
+        try:
+            ow = openweather.Openweather(
+                configuration['COLLECTOR']['openweathermap-key'],
+                configuration['COLLECTOR']['openweathermap-name'],
+                configuration['COLLECTOR']['openweathermap-city-id'])
+            openweather_enabled = True
+        except Exception as e:
+            logging.warn("OpenWeather has been disabled :(... due to " + str(e))
+            openweather_enabled = False
 
     logging.info("Loading " + DEVICES_FILE)
     with open(DEVICES_FILE) as f:

--- a/collector.py
+++ b/collector.py
@@ -196,7 +196,7 @@ def main():
                     temperature = ow.get_temperature()
                     if len(weather) > 16:#I should keep an eye on the length of "description" since this will go to the 16x2 LCD display
                             weather = weather[:16]
-                    dev.write_sensor(sensor, (temperature, weather))
+                    dev.write_sensor(sensor, (temperature, weather, 1))
             else:
                 logging.warn("Skipping " + dev.get_name() + " because is disabled.")
         back_to_sleep_for = (frequency - ((time.time() - starttime)%frequency))

--- a/device.py
+++ b/device.py
@@ -95,7 +95,7 @@ class Arduino(Device):
         message.append(sensor_id)			#B3 is actually the data format, so this is just a placeholder here.
 
         logging.debug("About to write to sensor " + self.available_sensors[sensor_id]['name'] + " type " + str(self.available_sensors[sensor_id]['type']))
-
+        logging.debug("Data to be written: " + str(data))
         if self.available_sensors[sensor_id]['type'] == 32: #Sensor is actually a LCD display
             temp = str(data[0])
             description = data[1]

--- a/device.py
+++ b/device.py
@@ -110,7 +110,7 @@ class Arduino(Device):
             for i in aux:
                 message.append(ord(i))
             message.append(ord('\n'))
-            message.append(slot.to_bytes(1, byteorder="little"))
+            message.append(ord(str(slot)) - 48)#Terrible workaround
         else:
             message.append(5) #B4
 

--- a/device.py
+++ b/device.py
@@ -99,7 +99,8 @@ class Arduino(Device):
         if self.available_sensors[sensor_id]['type'] == 32: #Sensor is actually a LCD display
             temp = str(data[0])
             description = data[1]
-            message.append(5 + len(temp) + 1 + len(description)) #B4 SIZE
+            slot = data[2]
+            message.append(5 + len(temp) + 1 + len(description) + 1 + 1) #B4 SIZE
             #Copy the letters one by one on the message payload.
             aux = list(temp)
             for i in aux:
@@ -108,6 +109,8 @@ class Arduino(Device):
             aux = list(description)
             for i in aux:
                 message.append(ord(i))
+            message.append(ord('\n'))
+            message.append(slot.to_bytes(1, byteorder="little"))
         else:
             message.append(5) #B4
 


### PR DESCRIPTION
There's a few things going on here:

- I added a 4 (LCD_PAIRS) slots for the LCD to rotate among them. However the idea of only showing the "enabled" slots instead of all of them didn't really take off. So all I could do so far is to show the default slot (0) before any other data is sent to the LCD, once at least one other slot is in use, slot 0 won't be shown anymore, however the other empty slots will be shown (all XXXXX).
- Also, I added an error message on the communication "protocol". This actually helped a lot to understand why the rotation was not working. Right now there's only 2 errors been flagged, and both of them are within the read_screen_data() function in arduino.ino. I should have done this on a separate branch...